### PR TITLE
refactor: remove unnecessary filter from `$aliases`

### DIFF
--- a/app/Config/Filters.php
+++ b/app/Config/Filters.php
@@ -22,7 +22,6 @@ class Filters extends BaseConfig
         'honeypot'      => Honeypot::class,
         'invalidchars'  => InvalidChars::class,
         'secureheaders' => SecureHeaders::class,
-        'session'       => \CodeIgniter\Shield\Filters\SessionAuth::class,
         'admin-auth'    => AdminAuth::class,
     ];
 


### PR DESCRIPTION
Shield filters are already loaded for you by the [registrar](https://codeigniter.com/user_guide/general/configuration.html#registrars) class located at src/Config/Registrar.php.